### PR TITLE
Adding CRPS to GaussianNN as another calibration metric

### DIFF
--- a/probcal/active_learning/active_learning_logger/active_learning_model_accuracy_logger.py
+++ b/probcal/active_learning/active_learning_logger/active_learning_model_accuracy_logger.py
@@ -35,6 +35,7 @@ class ActiveLearningModelAccuracyLogger(IObserver[ActiveLearningEvaluationResult
                         "MAE",
                         "RMSE",
                         "LOSS",
+                        "NLL",
                         "CRPS",
                     ]
                 )
@@ -52,6 +53,7 @@ class ActiveLearningModelAccuracyLogger(IObserver[ActiveLearningEvaluationResult
                 "metrics/mae": state.model_accuracy_results.test_mae,
                 "metrics/rmse": state.model_accuracy_results.test_rmse,
                 "metrics/loss": state.model_accuracy_results.test_loss,
+                "metrics/nll": state.model_accuracy_results.nll,
                 "metrics/crps": state.model_accuracy_results.crps,
             }
 
@@ -71,6 +73,7 @@ class ActiveLearningModelAccuracyLogger(IObserver[ActiveLearningEvaluationResult
                 state.model_accuracy_results.test_mae,
                 state.model_accuracy_results.test_rmse,
                 state.model_accuracy_results.test_loss,
+                state.model_accuracy_results.nll,
                 state.model_accuracy_results.crps,
             ]
             df = df.round(

--- a/probcal/active_learning/active_learning_logger/active_learning_model_accuracy_logger.py
+++ b/probcal/active_learning/active_learning_logger/active_learning_model_accuracy_logger.py
@@ -35,7 +35,7 @@ class ActiveLearningModelAccuracyLogger(IObserver[ActiveLearningEvaluationResult
                         "MAE",
                         "RMSE",
                         "LOSS",
-                        "NLL",
+                        "CRPS",
                     ]
                 )
 
@@ -52,7 +52,7 @@ class ActiveLearningModelAccuracyLogger(IObserver[ActiveLearningEvaluationResult
                 "metrics/mae": state.model_accuracy_results.test_mae,
                 "metrics/rmse": state.model_accuracy_results.test_rmse,
                 "metrics/loss": state.model_accuracy_results.test_loss,
-                "metrics/nll": state.model_accuracy_results.nll,
+                "metrics/crps": state.model_accuracy_results.crps,
             }
 
             # Log to WandB using the parent logger
@@ -71,7 +71,7 @@ class ActiveLearningModelAccuracyLogger(IObserver[ActiveLearningEvaluationResult
                 state.model_accuracy_results.test_mae,
                 state.model_accuracy_results.test_rmse,
                 state.model_accuracy_results.test_loss,
-                state.model_accuracy_results.nll,
+                state.model_accuracy_results.crps,
             ]
             df = df.round(
                 {col: 4 for col in df.select_dtypes(include=["float"]).columns}

--- a/probcal/active_learning/active_learning_types.py
+++ b/probcal/active_learning/active_learning_types.py
@@ -20,6 +20,7 @@ class ModelAccuracyResults:
     test_mae: float
     test_rmse: float
     nll: float | None = None
+    crps: float | None = None
 
 
 @dataclass

--- a/probcal/evaluation/custom_torchmetrics.py
+++ b/probcal/evaluation/custom_torchmetrics.py
@@ -56,7 +56,11 @@ class RegressionECE(Metric):
 
     def compute(self) -> torch.Tensor:
         param_dict = {
-            param_name: torch.cat(getattr(self, param_name)).flatten().detach().cpu().numpy()
+            param_name: torch.cat(getattr(self, param_name))
+            .flatten()
+            .detach()
+            .cpu()
+            .numpy()
             for param_name in self.param_list
         }
         self.posterior_predictive = self.rv_class_type(**param_dict)

--- a/probcal/evaluation/custom_torchmetrics.py
+++ b/probcal/evaluation/custom_torchmetrics.py
@@ -4,6 +4,7 @@ import matplotlib.pyplot as plt
 import numpy as np
 import torch
 from matplotlib.figure import Figure
+from properscoring import crps_gaussian
 from torchmetrics import Metric
 
 from probcal.evaluation.metrics import compute_regression_ece
@@ -55,11 +56,7 @@ class RegressionECE(Metric):
 
     def compute(self) -> torch.Tensor:
         param_dict = {
-            param_name: torch.cat(getattr(self, param_name))
-            .flatten()
-            .detach()
-            .cpu()
-            .numpy()
+            param_name: torch.cat(getattr(self, param_name)).flatten().detach().cpu().numpy()
             for param_name in self.param_list
         }
         self.posterior_predictive = self.rv_class_type(**param_dict)
@@ -134,3 +131,32 @@ class MedianPrecision(Metric):
         ax.set_ylabel("Density")
 
         return fig
+
+
+class ContinuousRankedProbabilityScore(Metric):
+    """A custom `torchmetric` for computing the average CRPS of Gaussian predictive distributions."""
+
+    def __init__(self, **kwargs):
+        self.add_state("all_crps", default=[], dist_reduce_fx="cat")
+
+    def update(self, mu: torch.Tensor, var: torch.Tensor, y: torch.Tensor):
+        """Update the internal state of this metric.
+
+        Args:
+            mu (torch.Tensor): A (N,) tensor of predictive means.
+            var (torch.Tensor): A (N,) tensor of predictive variances.
+            y (torch.Tensor): Regression targets that `mu` and `phi` form a prediction for. Shape: (N,).
+        """
+        assert y.ndim == 1
+        n = len(y)
+        assert mu.shape == var.shape == (n,)
+
+        mu = mu.detach().cpu().numpy()
+        sigma = var.sqrt().detach().cpu().numpy()
+        crps = crps_gaussian(y.detach().cpu().numpy(), mu, sigma)
+        crps = torch.tensor(crps, device=self.device)
+        self.all_crps.append(crps)
+
+    def compute(self) -> torch.Tensor:
+        all_crps = torch.cat(self.all_crps).flatten()
+        return torch.mean(all_crps)

--- a/probcal/models/gaussian_nn.py
+++ b/probcal/models/gaussian_nn.py
@@ -74,7 +74,9 @@ class GaussianNN(DiscreteRegressionNN):
             loss_fn=partial(
                 gaussian_nll,
                 beta=(
-                    self.beta_scheduler.current_value if self.beta_scheduler is not None else None
+                    self.beta_scheduler.current_value
+                    if self.beta_scheduler is not None
+                    else None
                 ),
             ),
             backbone_type=backbone_type,
@@ -122,7 +124,9 @@ class GaussianNN(DiscreteRegressionNN):
         # Apply torch.exp to the logvar dimension.
         output_shape = y_hat.shape
         reshaped = y_hat.view(-1, 2)
-        y_hat = torch.stack([reshaped[:, 0], torch.exp(reshaped[:, 1])], dim=1).view(*output_shape)
+        y_hat = torch.stack([reshaped[:, 0], torch.exp(reshaped[:, 1])], dim=1).view(
+            *output_shape
+        )
 
         return y_hat
 
@@ -155,7 +159,9 @@ class GaussianNN(DiscreteRegressionNN):
         dist = torch.distributions.Normal(loc=mu.squeeze(), scale=var.sqrt().squeeze())
         return dist
 
-    def _point_prediction_impl(self, y_hat: torch.Tensor, training: bool) -> torch.Tensor:
+    def _point_prediction_impl(
+        self, y_hat: torch.Tensor, training: bool
+    ) -> torch.Tensor:
         mu, _ = torch.split(y_hat, [1, 1], dim=-1)
         return mu.round()
 

--- a/requirements.in
+++ b/requirements.in
@@ -7,6 +7,7 @@ lightning==2.4.0
 open_clip_torch==2.26.1
 pip-tools==7.4.1
 pre-commit==3.8.0
+properscoring==0.1
 pycocotools==2.0.8
 torch==2.4.0
 torchmetrics==1.4.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,23 +4,25 @@
 #
 #    pip-compile requirements.in
 #
-aiohappyeyeballs==2.4.0
+aiohappyeyeballs==2.4.4
     # via aiohttp
-aiohttp==3.10.5
+aiohttp==3.11.11
     # via fsspec
-aiosignal==1.3.1
+aiosignal==1.3.2
     # via aiohttp
-anyio==4.7.0
+annotated-types==0.7.0
+    # via pydantic
+anyio==4.8.0
     # via httpx
-async-timeout==4.0.3
+async-timeout==5.0.1
     # via aiohttp
-attrs==24.2.0
+attrs==24.3.0
     # via aiohttp
 beautifulsoup4==4.12.3
     # via gdown
-build==1.2.2
+build==1.2.2.post1
     # via pip-tools
-certifi==2024.8.30
+certifi==2024.12.14
     # via
     #   httpcore
     #   httpx
@@ -28,19 +30,19 @@ certifi==2024.8.30
     #   sentry-sdk
 cfgv==3.4.0
     # via pre-commit
-charset-normalizer==3.3.2
+charset-normalizer==3.4.1
     # via requests
-click==8.1.7
+click==8.1.8
     # via
     #   pip-tools
     #   wandb
 colorama==0.4.6
     # via pretty-errors
-contourpy==1.3.0
+contourpy==1.3.1
     # via matplotlib
 cycler==0.12.1
     # via matplotlib
-distlib==0.3.8
+distlib==0.3.9
     # via virtualenv
 docker-pycreds==0.4.0
     # via wandb
@@ -53,25 +55,26 @@ filelock==3.16.1
     #   torch
     #   transformers
     #   virtualenv
-fonttools==4.53.1
+fonttools==4.55.3
     # via matplotlib
-frozenlist==1.4.1
+frozenlist==1.5.0
     # via
     #   aiohttp
     #   aiosignal
-fsspec[http]==2024.9.0
+fsspec[http]==2024.12.0
     # via
+    #   fsspec
     #   huggingface-hub
     #   lightning
     #   pytorch-lightning
     #   torch
-ftfy==6.2.3
+ftfy==6.3.1
     # via open-clip-torch
 gdown==5.2.0
     # via -r requirements.in
-gitdb==4.0.11
+gitdb==4.0.12
     # via gitpython
-gitpython==3.1.43
+gitpython==3.1.44
     # via wandb
 h11==0.14.0
     # via httpcore
@@ -79,13 +82,13 @@ httpcore==1.0.7
     # via httpx
 httpx==0.28.1
     # via -r requirements.in
-huggingface-hub==0.25.0
+huggingface-hub==0.27.1
     # via
     #   open-clip-torch
     #   timm
     #   tokenizers
     #   transformers
-identify==2.6.1
+identify==2.6.5
     # via pre-commit
 idna==3.10
     # via
@@ -93,20 +96,20 @@ idna==3.10
     #   httpx
     #   requests
     #   yarl
-jinja2==3.1.4
+jinja2==3.1.5
     # via torch
 joblib==1.4.2
     # via scikit-learn
-kiwisolver==1.4.7
+kiwisolver==1.4.8
     # via matplotlib
 lightning==2.4.0
     # via -r requirements.in
-lightning-utilities==0.11.7
+lightning-utilities==0.11.9
     # via
     #   lightning
     #   pytorch-lightning
     #   torchmetrics
-markupsafe==2.1.5
+markupsafe==3.0.2
     # via jinja2
 matplotlib==3.9.0
     # via
@@ -118,7 +121,7 @@ multidict==6.1.0
     # via
     #   aiohttp
     #   yarl
-networkx==3.3
+networkx==3.4.2
     # via torch
 nodeenv==1.9.1
     # via pre-commit
@@ -127,6 +130,7 @@ numpy==1.26.4
     #   -r requirements.in
     #   contourpy
     #   matplotlib
+    #   properscoring
     #   pycocotools
     #   scikit-learn
     #   scipy
@@ -135,7 +139,7 @@ numpy==1.26.4
     #   transformers
 open-clip-torch==2.26.1
     # via -r requirements.in
-packaging==24.1
+packaging==24.2
     # via
     #   build
     #   huggingface-hub
@@ -145,7 +149,7 @@ packaging==24.1
     #   pytorch-lightning
     #   torchmetrics
     #   transformers
-pillow==9.5.0
+pillow==11.1.0
     # via
     #   matplotlib
     #   torchvision
@@ -159,15 +163,25 @@ pre-commit==3.8.0
     # via -r requirements.in
 pretty-errors==1.2.25
     # via torchmetrics
-protobuf==5.29.2
+propcache==0.2.1
+    # via
+    #   aiohttp
+    #   yarl
+properscoring==0.1
+    # via -r requirements.in
+protobuf==5.29.3
     # via wandb
 psutil==6.1.1
     # via wandb
 pycocotools==2.0.8
     # via -r requirements.in
-pyparsing==3.1.4
+pydantic==2.10.5
+    # via wandb
+pydantic-core==2.27.2
+    # via pydantic
+pyparsing==3.2.1
     # via matplotlib
-pyproject-hooks==1.1.0
+pyproject-hooks==1.2.0
     # via
     #   build
     #   pip-tools
@@ -175,7 +189,7 @@ pysocks==1.7.1
     # via requests
 python-dateutil==2.9.0.post0
     # via matplotlib
-pytorch-lightning==2.4.0
+pytorch-lightning==2.5.0.post0
     # via lightning
 pyyaml==6.0.1
     # via
@@ -187,7 +201,7 @@ pyyaml==6.0.1
     #   timm
     #   transformers
     #   wandb
-regex==2024.9.11
+regex==2024.11.6
     # via
     #   open-clip-torch
     #   transformers
@@ -197,7 +211,7 @@ requests[socks]==2.32.3
     #   huggingface-hub
     #   transformers
     #   wandb
-safetensors==0.4.5
+safetensors==0.5.2
     # via
     #   timm
     #   transformers
@@ -206,30 +220,31 @@ scikit-learn==1.5.0
 scipy==1.13.1
     # via
     #   -r requirements.in
+    #   properscoring
     #   scikit-learn
 sentry-sdk==2.19.2
     # via wandb
 setproctitle==1.3.4
     # via wandb
-six==1.16.0
+six==1.17.0
     # via
     #   docker-pycreds
     #   python-dateutil
-smmap==5.0.1
+smmap==5.0.2
     # via gitdb
 sniffio==1.3.1
     # via anyio
 soupsieve==2.6
     # via beautifulsoup4
-sympy==1.13.2
+sympy==1.13.3
     # via torch
 threadpoolctl==3.5.0
     # via scikit-learn
-timm==1.0.9
+timm==1.0.13
     # via open-clip-torch
 tokenizers==0.19.1
     # via transformers
-tomli==2.0.1
+tomli==2.2.1
     # via
     #   build
     #   pip-tools
@@ -270,24 +285,26 @@ typing-extensions==4.12.2
     #   lightning
     #   lightning-utilities
     #   multidict
+    #   pydantic
+    #   pydantic-core
     #   pytorch-lightning
     #   torch
     #   wandb
-urllib3==2.2.3
+urllib3==2.3.0
     # via
     #   requests
     #   sentry-sdk
-virtualenv==20.26.5
+virtualenv==20.28.1
     # via pre-commit
-wandb==0.18.7
+wandb==0.19.2
     # via -r requirements.in
 wcwidth==0.2.13
     # via ftfy
 wget==3.2
     # via -r requirements.in
-wheel==0.44.0
+wheel==0.45.1
     # via pip-tools
-yarl==1.11.1
+yarl==1.18.3
     # via aiohttp
 
 # The following packages are considered to be unsafe in a requirements file:


### PR DESCRIPTION
Computing CRPS requires another external library, `properscoring`, which I added to the `requirements.in` and `requirements.txt`. So you'll just need to re-run `pip install -r requirements.txt` to run the new code.

I also wasn't sure if there is any code needed to "switch on" CRPS tracking for your Active Learning procedures. But CRPS will now auto-track on a model evaluation run just like `AverageNLL`.