### PR TITLE
Adding pure Gaussian NLL as a test metric

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ If fitting a model on tabular data, the training script assumes the dataset will
 
 ### Adding New Models
 
-All regression models should inherit from the `DiscreteRegressionNN` class (found [here](probcal/models/discrete_regression_nn.py)). This base class is a `lightning` module, which allows for a lot of typical NN boilerplate code to be abstracted away. Beyond setting a few class attributes like `loss_fn` while calling the super-initializer, the only methods you need to actually write to make a new module are:
+All regression models should inherit from the `RegressionNN` class (found [here](probcal/models/regression_nn.py)). This base class is a `lightning` module, which allows for a lot of typical NN boilerplate code to be abstracted away. Beyond setting a few class attributes like `loss_fn` while calling the super-initializer, the only methods you need to actually write to make a new module are:
 
 - `_forward_impl` (defines a forward pass through the network)
 - `_predict_impl` (defines how to make predictions with the network, including any transformations on the output of the forward pass)
@@ -76,7 +76,7 @@ Two results files will be saved to the `log_dir` you specify in your config:
 
 ## Measuring Calibration
 
-Once a `DiscreteRegressionNN` subclass is trained, its calibration can be measured on a dataset via the `CalibrationEvaluator`. Example usage:
+Once a `RegressionNN` subclass is trained, its calibration can be measured on a dataset via the `CalibrationEvaluator`. Example usage:
 
 ```python
 from probcal.data_modules import COCOPeopleDataModule

--- a/probcal/active_learning/active_learning_types.py
+++ b/probcal/active_learning/active_learning_types.py
@@ -2,14 +2,15 @@ import abc
 from dataclasses import dataclass
 
 import numpy as np
+
 from probcal.evaluation.calibration_evaluator import CalibrationResults
-from probcal.models.discrete_regression_nn import DiscreteRegressionNN
+from probcal.models.regression_nn import RegressionNN
 
 
 class IActiveLearningDataModuleDelegate(abc.ABC):
     @abc.abstractmethod
     def get_next_label_set(
-        self, unlabeled_indices: np.ndarray, k: int, model: DiscreteRegressionNN
+        self, unlabeled_indices: np.ndarray, k: int, model: RegressionNN
     ) -> np.ndarray:
         pass
 

--- a/probcal/active_learning/procedures/badge_procedure.py
+++ b/probcal/active_learning/procedures/badge_procedure.py
@@ -1,10 +1,11 @@
 import numpy as np
 from sklearn.metrics import pairwise_distances
-from probcal.active_learning.procedures.base import ActiveLearningProcedure
+
 from probcal.active_learning.active_learning_types import (
     ActiveLearningEvaluationResults,
 )
-from probcal.models.discrete_regression_nn import DiscreteRegressionNN
+from probcal.active_learning.procedures.base import ActiveLearningProcedure
+from probcal.models.regression_nn import RegressionNN
 
 
 class BadgeProcedure(ActiveLearningProcedure[ActiveLearningEvaluationResults]):
@@ -16,13 +17,13 @@ class BadgeProcedure(ActiveLearningProcedure[ActiveLearningEvaluationResults]):
         self,
         unlabeled_indices: np.ndarray,
         k: int,
-        model: DiscreteRegressionNN,
+        model: RegressionNN,
     ) -> np.ndarray:
         """
         Choose the next set of indices to add to the label set based on Badge sampling.
 
         Args:
-            model: DiscreteRegressionNN
+            model: RegressionNN
             unlabeled_indices: np.ndarray
             k: int
 

--- a/probcal/active_learning/procedures/base.py
+++ b/probcal/active_learning/procedures/base.py
@@ -1,5 +1,7 @@
 from abc import ABC
-from typing import TypeVar, Union, Any
+from typing import Any
+from typing import TypeVar
+from typing import Union
 
 import lightning
 import torch
@@ -7,17 +9,15 @@ from torch import Tensor
 from torch.utils.data import DataLoader
 from tqdm import tqdm
 
+from probcal.active_learning.active_learning_types import ActiveLearningEvaluationResults
+from probcal.active_learning.active_learning_types import IActiveLearningDataModuleDelegate
+from probcal.active_learning.active_learning_types import ModelAccuracyResults
 from probcal.active_learning.configs import ActiveLearningConfig
-from probcal.active_learning.active_learning_types import (
-    ActiveLearningEvaluationResults,
-    IActiveLearningDataModuleDelegate,
-    ModelAccuracyResults,
-)
 from probcal.active_learning.procedures.utils import seed_torch
 from probcal.data_modules.active_learning_data_module import ActiveLearningDataModule
 from probcal.evaluation import CalibrationEvaluator
 from probcal.lib.observer import Subject
-from probcal.models.discrete_regression_nn import DiscreteRegressionNN
+from probcal.models.regression_nn import RegressionNN
 
 
 T = TypeVar("T")
@@ -43,7 +43,7 @@ class ActiveLearningProcedure(
     def eval(
         self,
         trainer: lightning.Trainer,
-        model: DiscreteRegressionNN | None = None,
+        model: RegressionNN | None = None,
         best_path: str | None = None,
     ):
         """
@@ -62,9 +62,7 @@ class ActiveLearningProcedure(
         assert (
             model is not None or best_path is not None
         ), "`model` or `best_path` must be defined."
-        results = trainer.test(
-            model=model, ckpt_path=best_path, datamodule=self.dataset
-        )
+        results = trainer.test(model=model, ckpt_path=best_path, datamodule=self.dataset)
         model_accuracy_results = ModelAccuracyResults(**results[0])
         eval_dict = {
             "kth_trial": self._k,
@@ -85,7 +83,7 @@ class ActiveLearningProcedure(
     def _eval_ext(
         self,
         trainer: lightning.Trainer,
-        model: DiscreteRegressionNN | None = None,
+        model: RegressionNN | None = None,
         best_path: str | None = None,
     ) -> tuple[type[EvalState], dict[str, Any]]:
         """
@@ -94,7 +92,7 @@ class ActiveLearningProcedure(
         """
         return ActiveLearningEvaluationResults, {}
 
-    def step(self, model: DiscreteRegressionNN):
+    def step(self, model: RegressionNN):
         """
         Update `self.dataset` to include pool the unlabeled samples
         from AL into the training pool
@@ -123,7 +121,7 @@ class ActiveLearningProcedure(
         self._state = evaluation
 
     @staticmethod
-    def get_embedding(model: DiscreteRegressionNN, loader: DataLoader) -> Tensor:
+    def get_embedding(model: RegressionNN, loader: DataLoader) -> Tensor:
         """
         Returns the embedding of the given model by extracting last layer representations
         """

--- a/probcal/active_learning/procedures/batchbald_procedure.py
+++ b/probcal/active_learning/procedures/batchbald_procedure.py
@@ -1,18 +1,11 @@
 import numpy as np
-import torch
-from torch.utils.data import DataLoader, TensorDataset
-import gc
-from tqdm import tqdm
-from copy import copy as copy
-from copy import deepcopy as deepcopy
-from torch.autograd import Variable
-from torch.nn import functional as F
-from probcal.active_learning.procedures.base import ActiveLearningProcedure
+from sklearn.metrics import pairwise_distances
+
 from probcal.active_learning.active_learning_types import (
     ActiveLearningEvaluationResults,
 )
-from probcal.models.discrete_regression_nn import DiscreteRegressionNN
-from sklearn.metrics import pairwise_distances
+from probcal.active_learning.procedures.base import ActiveLearningProcedure
+from probcal.models.regression_nn import RegressionNN
 
 
 class BatchBALDProcedure(ActiveLearningProcedure[ActiveLearningEvaluationResults]):
@@ -25,13 +18,13 @@ class BatchBALDProcedure(ActiveLearningProcedure[ActiveLearningEvaluationResults
         self,
         unlabeled_indices: np.ndarray,
         k: int,
-        model: DiscreteRegressionNN,
+        model: RegressionNN,
     ) -> np.ndarray:
         """
         Choose the next set of indices to add to the label set based on MaxDet.
 
         Args:
-            model: DiscreteRegressionNN
+            model: RegressionNN
             unlabeled_indices: np.ndarray
             k: int
 

--- a/probcal/active_learning/procedures/cce_active_learning_procedure.py
+++ b/probcal/active_learning/procedures/cce_active_learning_procedure.py
@@ -7,7 +7,7 @@ from probcal.active_learning.active_learning_types import (
 from probcal.active_learning.procedures.base import (
     ActiveLearningProcedure,
 )
-from probcal.models.discrete_regression_nn import DiscreteRegressionNN
+from probcal.models.regression_nn import RegressionNN
 
 
 class CCEProcedure(ActiveLearningProcedure[ActiveLearningEvaluationResults]):
@@ -15,7 +15,7 @@ class CCEProcedure(ActiveLearningProcedure[ActiveLearningEvaluationResults]):
         self,
         unlabeled_indices: np.ndarray,
         k: int,
-        model: DiscreteRegressionNN,
+        model: RegressionNN,
     ) -> np.ndarray:
         model = model.to("cpu")
         train_dataloader = self.dataset.train_dataloader()
@@ -26,8 +26,6 @@ class CCEProcedure(ActiveLearningProcedure[ActiveLearningEvaluationResults]):
             data_loader=train_dataloader,
         )
         assert cce_unlabeled.shape[0] == len(unlabeled_indices)
-        _, sampling_indices = torch.topk(
-            cce_unlabeled, k=min(k, unlabeled_indices.shape[0])
-        )
+        _, sampling_indices = torch.topk(cce_unlabeled, k=min(k, unlabeled_indices.shape[0]))
 
         return unlabeled_indices[sampling_indices]

--- a/probcal/active_learning/procedures/confidence_active_learning_procedure.py
+++ b/probcal/active_learning/procedures/confidence_active_learning_procedure.py
@@ -1,24 +1,24 @@
 import numpy as np
 import torch
-from tqdm import tqdm
 from torch.utils.data import DataLoader
+from tqdm import tqdm
 
 from probcal.active_learning.procedures.base import (
     ActiveLearningProcedure,
 )
-from probcal.models.discrete_regression_nn import DiscreteRegressionNN
+from probcal.models.regression_nn import RegressionNN
 
 
 class ConfidenceProcedure(ActiveLearningProcedure[ActiveLearningProcedure]):
     def get_next_label_set(
-        self, unlabeled_indices: np.ndarray, k: int, model: DiscreteRegressionNN
+        self, unlabeled_indices: np.ndarray, k: int, model: RegressionNN
     ) -> np.ndarray:
         """
         Randomly choose the next set of indices to add to label set
         Args:
             unlabeled_indices: np.ndarray
             k: int
-            model: DiscreteRegressionNN
+            model: RegressionNN
 
         Returns:
             A random subset of unlabeled indices.
@@ -29,21 +29,17 @@ class ConfidenceProcedure(ActiveLearningProcedure[ActiveLearningProcedure]):
             data_loader=unlabeled_dataloader,
         )
         assert confidence.shape[0] == len(unlabeled_indices)
-        _, sampling_indices = torch.topk(
-            confidence, k=min(k, unlabeled_indices.shape[0])
-        )
+        _, sampling_indices = torch.topk(confidence, k=min(k, unlabeled_indices.shape[0]))
 
         return unlabeled_indices[sampling_indices]
 
     @staticmethod
     def get_confidence_score_from_model(
-        model: DiscreteRegressionNN, data_loader: DataLoader
+        model: RegressionNN, data_loader: DataLoader
     ) -> torch.Tensor:
         with torch.no_grad():
             conf = []
-            for inputs, _ in tqdm(
-                data_loader, desc="doing forward pass to compute confidence..."
-            ):
+            for inputs, _ in tqdm(data_loader, desc="doing forward pass to compute confidence..."):
                 y_hat = model.predict(inputs.to(model.device))
                 (mu, var) = torch.split(y_hat, [1, 1], dim=-1)
                 conf.append(var.flatten())

--- a/probcal/active_learning/procedures/coreset_procedure.py
+++ b/probcal/active_learning/procedures/coreset_procedure.py
@@ -1,20 +1,11 @@
 import numpy as np
-import torch
-from torch.utils.data import DataLoader, TensorDataset
-import numpy as np
-import gc
-from tqdm import tqdm
-from copy import copy as copy
-from copy import deepcopy as deepcopy
-from torch.autograd import Variable
-from torch.nn import functional as F
-import numpy as np
-from probcal.active_learning.procedures.base import ActiveLearningProcedure
+from sklearn.metrics import pairwise_distances
+
 from probcal.active_learning.active_learning_types import (
     ActiveLearningEvaluationResults,
 )
-from probcal.models.discrete_regression_nn import DiscreteRegressionNN
-from sklearn.metrics import pairwise_distances
+from probcal.active_learning.procedures.base import ActiveLearningProcedure
+from probcal.models.regression_nn import RegressionNN
 
 
 class CoreSetProcedure(ActiveLearningProcedure[ActiveLearningEvaluationResults]):
@@ -25,13 +16,13 @@ class CoreSetProcedure(ActiveLearningProcedure[ActiveLearningEvaluationResults])
         self,
         unlabeled_indices: np.ndarray,
         k: int,
-        model: DiscreteRegressionNN,
+        model: RegressionNN,
     ) -> np.ndarray:
         """
         Choose the next set of indices to add to the label set based on Fisher Information.
 
         Args:
-            model: DiscreteRegressionNN
+            model: RegressionNN
             unlabeled_indices: np.ndarray
             k: int
 

--- a/probcal/active_learning/procedures/lcmd/lcmd_procedure.py
+++ b/probcal/active_learning/procedures/lcmd/lcmd_procedure.py
@@ -12,20 +12,16 @@ from probcal.active_learning.procedures.lcmd.features import Features
 from probcal.active_learning.procedures.lcmd.selection import (
     LargestClusterMaxDistSelectionMethod,
 )
-from probcal.models.discrete_regression_nn import DiscreteRegressionNN
+from probcal.models.regression_nn import RegressionNN
 
 
 class LCMDProcedure(ActiveLearningProcedure[ActiveLearningEvaluationResults]):
     def get_next_label_set(
-        self, unlabeled_indices: np.ndarray, k: int, model: DiscreteRegressionNN
+        self, unlabeled_indices: np.ndarray, k: int, model: RegressionNN
     ) -> np.ndarray:
         feature_data = self.get_tensor_features(model)
-        feature_map = IdentityFeatureMap(
-            n_features=feature_data["train"].get_tensor(0).shape[-1]
-        )
-        features = {
-            key: Features(feature_map, data) for key, data in feature_data.items()
-        }
+        feature_map = IdentityFeatureMap(n_features=feature_data["train"].get_tensor(0).shape[-1])
+        features = {key: Features(feature_map, data) for key, data in feature_data.items()}
         alg = LargestClusterMaxDistSelectionMethod(
             pool_features=features["pool"],
             train_features=features["train"],
@@ -39,9 +35,7 @@ class LCMDProcedure(ActiveLearningProcedure[ActiveLearningEvaluationResults]):
         )
         return unlabeled_indices[selected_indices]
 
-    def get_tensor_features(
-        self, model: DiscreteRegressionNN
-    ) -> dict[str, TensorFeatureData]:
+    def get_tensor_features(self, model: RegressionNN) -> dict[str, TensorFeatureData]:
         train = self.get_embedding(model, loader=self.dataset.train_dataloader())
         pool = self.get_embedding(model, loader=self.dataset.unlabeled_dataloader())
         return {

--- a/probcal/active_learning/procedures/random_procedure.py
+++ b/probcal/active_learning/procedures/random_procedure.py
@@ -6,19 +6,19 @@ from probcal.active_learning.active_learning_types import (
 from probcal.active_learning.procedures.base import (
     ActiveLearningProcedure,
 )
-from probcal.models.discrete_regression_nn import DiscreteRegressionNN
+from probcal.models.regression_nn import RegressionNN
 
 
 class RandomProcedure(ActiveLearningProcedure[ActiveLearningEvaluationResults]):
     def get_next_label_set(
-        self, unlabeled_indices: np.ndarray, k: int, model: DiscreteRegressionNN
+        self, unlabeled_indices: np.ndarray, k: int, model: RegressionNN
     ) -> np.ndarray:
         """
         Randomly choose the next set of indices to add to label set
         Args:
             unlabeled_indices: np.ndarray
             k: int
-            model: DiscreteRegressionNN
+            model: RegressionNN
 
         Returns:
             A random subset of unlabeled indices.

--- a/probcal/active_learning/procedures/reverse_cce_active_learning_procedure.py
+++ b/probcal/active_learning/procedures/reverse_cce_active_learning_procedure.py
@@ -7,7 +7,7 @@ from probcal.active_learning.active_learning_types import (
 from probcal.active_learning.procedures.base import (
     ActiveLearningProcedure,
 )
-from probcal.models.discrete_regression_nn import DiscreteRegressionNN
+from probcal.models.regression_nn import RegressionNN
 
 
 class ReverseCCEProcedure(ActiveLearningProcedure[ActiveLearningEvaluationResults]):
@@ -15,7 +15,7 @@ class ReverseCCEProcedure(ActiveLearningProcedure[ActiveLearningEvaluationResult
         self,
         unlabeled_indices: np.ndarray,
         k: int,
-        model: DiscreteRegressionNN,
+        model: RegressionNN,
     ) -> np.ndarray:
         """
         Randomly choose the next set of indices to add to label set

--- a/probcal/active_learning/procedures/softmax_ace.py
+++ b/probcal/active_learning/procedures/softmax_ace.py
@@ -9,7 +9,7 @@ from probcal.active_learning.procedures.base import (
     ActiveLearningProcedure,
 )
 from probcal.data_modules.active_learning_data_module import ActiveLearningDataModule
-from probcal.models.discrete_regression_nn import DiscreteRegressionNN
+from probcal.models.regression_nn import RegressionNN
 from probcal.training.hyperparam_schedulers import CosineAnnealingScheduler
 
 
@@ -35,7 +35,7 @@ class SoftmaxACEProcedure(ActiveLearningProcedure[ActiveLearningEvaluationResult
         self,
         unlabeled_indices: np.ndarray,
         k: int,
-        model: DiscreteRegressionNN,
+        model: RegressionNN,
     ) -> np.ndarray:
         model = model.to("cpu")
         train_dataloader = self.dataset.train_dataloader()
@@ -51,9 +51,7 @@ class SoftmaxACEProcedure(ActiveLearningProcedure[ActiveLearningEvaluationResult
         tau = self.tau_scheduler.current_value
         sampling_probs = torch.softmax(cce_unlabeled / tau, dim=-1)
         num_samples = min(k, n)
-        sampling_indices = (
-            torch.multinomial(sampling_probs, num_samples).detach().cpu().numpy()
-        )
+        sampling_indices = torch.multinomial(sampling_probs, num_samples).detach().cpu().numpy()
         self.tau_scheduler.step()
 
         return unlabeled_indices[sampling_indices]

--- a/probcal/active_learning/procedures/weighted_ace.py
+++ b/probcal/active_learning/procedures/weighted_ace.py
@@ -7,7 +7,7 @@ from probcal.active_learning.active_learning_types import (
 from probcal.active_learning.procedures.base import (
     ActiveLearningProcedure,
 )
-from probcal.models.discrete_regression_nn import DiscreteRegressionNN
+from probcal.models.regression_nn import RegressionNN
 
 
 class WeightedACEProcedure(ActiveLearningProcedure[ActiveLearningEvaluationResults]):
@@ -17,7 +17,7 @@ class WeightedACEProcedure(ActiveLearningProcedure[ActiveLearningEvaluationResul
         self,
         unlabeled_indices: np.ndarray,
         k: int,
-        model: DiscreteRegressionNN,
+        model: RegressionNN,
     ) -> np.ndarray:
         model = model.to("cpu")
         train_dataloader = self.dataset.train_dataloader()
@@ -32,8 +32,6 @@ class WeightedACEProcedure(ActiveLearningProcedure[ActiveLearningEvaluationResul
 
         sampling_probs = cce_unlabeled / cce_unlabeled.sum()
         num_samples = min(k, n)
-        sampling_indices = (
-            torch.multinomial(sampling_probs, num_samples).detach().cpu().numpy()
-        )
+        sampling_indices = torch.multinomial(sampling_probs, num_samples).detach().cpu().numpy()
 
         return unlabeled_indices[sampling_indices]

--- a/probcal/data_modules/active_learning_data_module.py
+++ b/probcal/data_modules/active_learning_data_module.py
@@ -1,17 +1,18 @@
-from pathlib import Path
-from typing import Union, Sized
+from typing import Sized
+from typing import Union
 
 import numpy as np
 from numpy import ndarray
-from torch.utils.data import Dataset, Subset
-from torchvision.transforms import Compose
 from torch.utils.data import DataLoader
+from torch.utils.data import Dataset
+from torch.utils.data import Subset
+from torchvision.transforms import Compose
 
 from probcal.active_learning.configs import ActiveLearningConfig
 from probcal.active_learning.procedures.base import IActiveLearningDataModuleDelegate
 from probcal.custom_datasets import ImageDatasetWrapper
 from probcal.data_modules.prob_cal_data_module import ProbCalDataModule
-from probcal.models.discrete_regression_nn import DiscreteRegressionNN
+from probcal.models.regression_nn import RegressionNN
 
 
 class ActiveLearningDataModule(ProbCalDataModule):
@@ -40,9 +41,7 @@ class ActiveLearningDataModule(ProbCalDataModule):
             seed=seed,
         )
 
-    def step(
-        self, delegate: IActiveLearningDataModuleDelegate, model: DiscreteRegressionNN
-    ):
+    def step(self, delegate: IActiveLearningDataModuleDelegate, model: RegressionNN):
         # The delegate will tell me how to get my next labeled set
         # i.e. random, CCEActiveLearning, etc.
         unlabeled_indices_to_label = delegate.get_next_label_set(
@@ -60,12 +59,8 @@ class ActiveLearningDataModule(ProbCalDataModule):
             self.train_indices = np.union1d(self.train_indices, new_train_indices)
             self.val_indices = np.union1d(self.val_indices, new_val_indices)
         else:
-            self.train_indices = np.union1d(
-                self.train_indices, unlabeled_indices_to_label
-            )
-        self.unlabeled_indices = np.setdiff1d(
-            self.unlabeled_indices, unlabeled_indices_to_label
-        )
+            self.train_indices = np.union1d(self.train_indices, unlabeled_indices_to_label)
+        self.unlabeled_indices = np.setdiff1d(self.unlabeled_indices, unlabeled_indices_to_label)
 
     def _init_indices(self, seed=1998):
         num_instances = len(self.full_dataset)

--- a/probcal/evaluation/custom_torchmetrics.py
+++ b/probcal/evaluation/custom_torchmetrics.py
@@ -5,6 +5,7 @@ import numpy as np
 import torch
 from matplotlib.figure import Figure
 from properscoring import crps_gaussian
+from torch.nn.functional import gaussian_nll_loss
 from torchmetrics import Metric
 
 from probcal.evaluation.metrics import compute_regression_ece
@@ -56,11 +57,7 @@ class RegressionECE(Metric):
 
     def compute(self) -> torch.Tensor:
         param_dict = {
-            param_name: torch.cat(getattr(self, param_name))
-            .flatten()
-            .detach()
-            .cpu()
-            .numpy()
+            param_name: torch.cat(getattr(self, param_name)).flatten().detach().cpu().numpy()
             for param_name in self.param_list
         }
         self.posterior_predictive = self.rv_class_type(**param_dict)
@@ -149,7 +146,7 @@ class ContinuousRankedProbabilityScore(Metric):
         Args:
             mu (torch.Tensor): A (N,) tensor of predictive means.
             var (torch.Tensor): A (N,) tensor of predictive variances.
-            y (torch.Tensor): Regression targets that `mu` and `phi` form a prediction for. Shape: (N,).
+            y (torch.Tensor): Regression targets that `mu` and `var` form a prediction for. Shape: (N,).
         """
         assert y.ndim == 1
         n = len(y)
@@ -164,3 +161,29 @@ class ContinuousRankedProbabilityScore(Metric):
     def compute(self) -> torch.Tensor:
         all_crps = torch.cat(self.all_crps).flatten()
         return torch.mean(all_crps)
+
+
+class GaussianNLL(Metric):
+    """Computes the average negative log Gaussian density assigned to the true target."""
+
+    def __init__(self, **kwargs):
+        self.add_state("all_nlls", default=[], dist_reduce_fx="cat")
+
+    def update(self, mu: torch.Tensor, var: torch.Tensor, y: torch.Tensor):
+        """Update the internal state of this metric.
+
+        Args:
+            mu (torch.Tensor): A (N,) tensor of predictive means.
+            var (torch.Tensor): A (N,) tensor of predictive variances.
+            y (torch.Tensor): Regression targets that `mu` and `var` form a prediction for. Shape: (N,).
+        """
+        assert y.ndim == 1
+        n = len(y)
+        assert mu.shape == var.shape == (n,)
+
+        nlls = gaussian_nll_loss(mu, y, var, full=True, reduction="none")
+        self.all_nlls.append(nlls)
+
+    def compute(self) -> torch.Tensor:
+        all_nlls = torch.cat(self.all_nlls).flatten()
+        return torch.mean(all_nlls)

--- a/probcal/evaluation/eval_model.py
+++ b/probcal/evaluation/eval_model.py
@@ -12,7 +12,7 @@ from probcal.enums import DatasetType
 from probcal.evaluation.calibration_evaluator import CalibrationEvaluator
 from probcal.evaluation.calibration_evaluator import CalibrationEvaluatorSettings
 from probcal.evaluation.kernels import rbf_kernel
-from probcal.models.discrete_regression_nn import DiscreteRegressionNN
+from probcal.models.regression_nn import RegressionNN
 from probcal.utils.configs import EvaluationConfig
 from probcal.utils.experiment_utils import get_datamodule
 from probcal.utils.experiment_utils import get_model
@@ -29,9 +29,7 @@ def main(config_path: Path):
         config.batch_size,
     )
 
-    initializer: Type[DiscreteRegressionNN] = get_model(
-        config, return_initializer=True
-    )[1]
+    initializer: Type[RegressionNN] = get_model(config, return_initializer=True)[1]
     model = initializer.load_from_checkpoint(config.model_ckpt_path)
     evaluator = L.Trainer(
         accelerator=config.accelerator_type.value,

--- a/probcal/figures/generate_mcmd_in_practice_figure.py
+++ b/probcal/figures/generate_mcmd_in_practice_figure.py
@@ -20,13 +20,13 @@ from probcal.models import DoublePoissonNN
 from probcal.models import GaussianNN
 from probcal.models import NegBinomNN
 from probcal.models import PoissonNN
-from probcal.models.discrete_regression_nn import DiscreteRegressionNN
+from probcal.models.regression_nn import RegressionNN
 from probcal.random_variables import DoublePoisson
 from probcal.utils.multiple_formatter import multiple_formatter
 
 
 def produce_figure(
-    models: list[DiscreteRegressionNN],
+    models: list[RegressionNN],
     names: list[str],
     save_path: Path | str,
     dataset_path: Path | str,
@@ -34,7 +34,7 @@ def produce_figure(
     """Create a figure showcasing the MCMD's ability to identify calibrated models.
 
     Args:
-        models (list[DiscreteRegressionNN]): List of models to plot posterior predictive distributions of.
+        models (list[RegressionNN]): List of models to plot posterior predictive distributions of.
         names (list[str]): List of display names for each respective model in `models`.
         save_path (Path | str): Path to save figure to.
         dataset_path (Path | str): Path with dataset models were fit on.

--- a/probcal/models/faithful_gaussian_nn.py
+++ b/probcal/models/faithful_gaussian_nn.py
@@ -8,11 +8,11 @@ from probcal.enums import LRSchedulerType
 from probcal.enums import OptimizerType
 from probcal.evaluation.custom_torchmetrics import AverageNLL
 from probcal.models.backbones import Backbone
-from probcal.models.discrete_regression_nn import DiscreteRegressionNN
+from probcal.models.regression_nn import RegressionNN
 from probcal.training.losses import faithful_gaussian_nll
 
 
-class FaithfulGaussianNN(DiscreteRegressionNN):
+class FaithfulGaussianNN(RegressionNN):
     """Implementation of https://arxiv.org/abs/2212.09184.
 
     Attributes:
@@ -94,9 +94,7 @@ class FaithfulGaussianNN(DiscreteRegressionNN):
         # Apply torch.exp to the logvar dimension.
         output_shape = y_hat.shape
         reshaped = y_hat.view(-1, 2)
-        y_hat = torch.stack([reshaped[:, 0], torch.exp(reshaped[:, 1])], dim=1).view(
-            *output_shape
-        )
+        y_hat = torch.stack([reshaped[:, 0], torch.exp(reshaped[:, 1])], dim=1).view(*output_shape)
 
         return y_hat
 
@@ -129,11 +127,9 @@ class FaithfulGaussianNN(DiscreteRegressionNN):
         dist = torch.distributions.Normal(loc=mu.squeeze(), scale=var.sqrt().squeeze())
         return dist
 
-    def _point_prediction_impl(
-        self, y_hat: torch.Tensor, training: bool
-    ) -> torch.Tensor:
+    def _point_prediction_impl(self, y_hat: torch.Tensor, training: bool) -> torch.Tensor:
         mu, _ = torch.split(y_hat, [1, 1], dim=-1)
-        return mu.round()
+        return mu
 
     def _addl_test_metrics_dict(self) -> dict[str, Metric]:
         return {"nll": self.nll}

--- a/probcal/models/natural_gaussian_nn.py
+++ b/probcal/models/natural_gaussian_nn.py
@@ -9,11 +9,11 @@ from probcal.enums import LRSchedulerType
 from probcal.enums import OptimizerType
 from probcal.evaluation.custom_torchmetrics import AverageNLL
 from probcal.models.backbones import Backbone
-from probcal.models.discrete_regression_nn import DiscreteRegressionNN
+from probcal.models.regression_nn import RegressionNN
 from probcal.training.losses import natural_gaussian_nll
 
 
-class NaturalGaussianNN(DiscreteRegressionNN):
+class NaturalGaussianNN(RegressionNN):
     """A neural network that learns the natural parameters of a Gaussian distribution over each regression target (conditioned on the input).
 
     Attributes:
@@ -118,12 +118,10 @@ class NaturalGaussianNN(DiscreteRegressionNN):
         dist = torch.distributions.Normal(loc=mu, scale=std)
         return dist
 
-    def _point_prediction_impl(
-        self, y_hat: torch.Tensor, training: bool
-    ) -> torch.Tensor:
+    def _point_prediction_impl(self, y_hat: torch.Tensor, training: bool) -> torch.Tensor:
         eta_1, eta_2 = torch.split(y_hat, [1, 1], dim=-1)
         mu = self._natural_to_mu(eta_1, eta_2)
-        return mu.round()
+        return mu
 
     def _addl_test_metrics_dict(self) -> dict[str, Metric]:
         return {"nll": self.nll}

--- a/probcal/models/neg_binom_nn.py
+++ b/probcal/models/neg_binom_nn.py
@@ -8,11 +8,11 @@ from probcal.enums import LRSchedulerType
 from probcal.enums import OptimizerType
 from probcal.evaluation.custom_torchmetrics import AverageNLL
 from probcal.models.backbones import Backbone
-from probcal.models.discrete_regression_nn import DiscreteRegressionNN
+from probcal.models.regression_nn import RegressionNN
 from probcal.training.losses import neg_binom_nll
 
 
-class NegBinomNN(DiscreteRegressionNN):
+class NegBinomNN(RegressionNN):
     """A neural network that learns the parameters of a Negative Binomial distribution over each regression target (conditioned on the input).
 
     The mean-scale (mu, alpha) parametrization of the Negative Binomial is used for this network.
@@ -127,9 +127,7 @@ class NegBinomNN(DiscreteRegressionNN):
         dist = torch.distributions.NegativeBinomial(total_count=n, probs=failure_prob)
         return dist
 
-    def _point_prediction_impl(
-        self, y_hat: torch.Tensor, training: bool
-    ) -> torch.Tensor:
+    def _point_prediction_impl(self, y_hat: torch.Tensor, training: bool) -> torch.Tensor:
         dist = self.posterior_predictive(y_hat, training)
         return dist.mode
 

--- a/probcal/models/poisson_nn.py
+++ b/probcal/models/poisson_nn.py
@@ -11,10 +11,10 @@ from probcal.enums import LRSchedulerType
 from probcal.enums import OptimizerType
 from probcal.evaluation.custom_torchmetrics import AverageNLL
 from probcal.models.backbones import Backbone
-from probcal.models.discrete_regression_nn import DiscreteRegressionNN
+from probcal.models.regression_nn import RegressionNN
 
 
-class PoissonNN(DiscreteRegressionNN):
+class PoissonNN(RegressionNN):
     """A neural network that learns the parameters of a Poisson distribution over each regression target (conditioned on the input).
 
     Attributes:
@@ -111,9 +111,7 @@ class PoissonNN(DiscreteRegressionNN):
         dist = torch.distributions.Poisson(lmbda.squeeze())
         return dist
 
-    def _point_prediction_impl(
-        self, y_hat: torch.Tensor, training: bool
-    ) -> torch.Tensor:
+    def _point_prediction_impl(self, y_hat: torch.Tensor, training: bool) -> torch.Tensor:
         lmbda = y_hat.exp() if training else y_hat
         return lmbda.floor()
 

--- a/probcal/training/train_model.py
+++ b/probcal/training/train_model.py
@@ -1,15 +1,16 @@
-import math
 from argparse import ArgumentParser
 from argparse import Namespace
 
 import lightning as L
-from lightning import LightningDataModule, Callback
+from lightning import Callback
+from lightning import LightningDataModule
 from lightning.pytorch.callbacks import EarlyStopping
+from lightning.pytorch.loggers import CSVLogger
+from lightning.pytorch.loggers import WandbLogger
 from lightning.pytorch.loggers.logger import Logger
-from lightning.pytorch.loggers import CSVLogger, WandbLogger
 
 from probcal.lib.logging import WandBLoggingCallback
-from probcal.models.discrete_regression_nn import DiscreteRegressionNN
+from probcal.models.regression_nn import RegressionNN
 from probcal.utils.configs import TrainingConfig
 from probcal.utils.experiment_utils import fix_random_seed
 from probcal.utils.experiment_utils import get_chkp_callbacks
@@ -18,7 +19,7 @@ from probcal.utils.experiment_utils import get_model
 
 
 def train_procedure(
-    model: DiscreteRegressionNN,
+    model: RegressionNN,
     datamodule: LightningDataModule,
     config: TrainingConfig,
     callbacks: list[Callback] | None,

--- a/probcal/utils/experiment_utils.py
+++ b/probcal/utils/experiment_utils.py
@@ -9,38 +9,39 @@ import numpy as np
 import torch
 import yaml
 from lightning import Callback
-
 from lightning.pytorch.callbacks import ModelCheckpoint
 
 from probcal.active_learning.configs import CheckpointType
-from probcal.data_modules import (
-    AAFDataModule,
-    COCOPeopleDataModule,
-    EVADataModule,
-    FGNetDataModule,
-    OodBlurCocoPeopleDataModule,
-    OodLabelNoiseCocoPeopleDataModule,
-    OodMixupCocoPeopleDataModule,
-    TabularDataModule,
-    WikiDataModule,
-    ReviewsDataModule,
-)
+from probcal.data_modules import AAFDataModule
+from probcal.data_modules import COCOPeopleDataModule
+from probcal.data_modules import EVADataModule
+from probcal.data_modules import FGNetDataModule
+from probcal.data_modules import OodBlurCocoPeopleDataModule
+from probcal.data_modules import OodLabelNoiseCocoPeopleDataModule
+from probcal.data_modules import OodMixupCocoPeopleDataModule
+from probcal.data_modules import ReviewsDataModule
+from probcal.data_modules import TabularDataModule
+from probcal.data_modules import WikiDataModule
 from probcal.data_modules.prob_cal_data_module import ProbCalDataModule
-from probcal.enums import DatasetType, HeadType, ImageDatasetName, TextDatasetName
+from probcal.enums import DatasetType
+from probcal.enums import HeadType
+from probcal.enums import ImageDatasetName
+from probcal.enums import TextDatasetName
 from probcal.models import DoublePoissonNN
 from probcal.models import FaithfulGaussianNN
+from probcal.models import FeedForwardNN
 from probcal.models import GaussianNN
 from probcal.models import NaturalGaussianNN
 from probcal.models import NegBinomNN
 from probcal.models import PoissonNN
-from probcal.models import FeedForwardNN
-from probcal.models.backbones import DistilBert, Backbone
+from probcal.models.backbones import Backbone
+from probcal.models.backbones import DistilBert
 from probcal.models.backbones import LargerMLP
 from probcal.models.backbones import MLP
 from probcal.models.backbones import MNISTCNN
 from probcal.models.backbones import MobileNetV3
 from probcal.models.backbones import ViT
-from probcal.models.discrete_regression_nn import DiscreteRegressionNN
+from probcal.models.regression_nn import RegressionNN
 from probcal.utils.configs import EvaluationConfig
 from probcal.utils.configs import TrainingConfig
 from probcal.utils.generic_utils import partialclass
@@ -55,9 +56,7 @@ def get_backbone_from_config(
     subclasses = Backbone.__subclasses__()
     Class = list(filter(lambda c: c.__name__ == backbone_type, subclasses))[0]
     if Class is None:
-        raise ValueError(
-            f"{backbone_type} is not a valid backbone. Must be one of [{subclasses}]"
-        )
+        raise ValueError(f"{backbone_type} is not a valid backbone. Must be one of [{subclasses}]")
     kwargs = {}
     if config.dataset_type == DatasetType.TABULAR:
         kwargs.update({"input_dim": config.input_dim})
@@ -84,22 +83,17 @@ def get_backbone_from_dataset(
         else:
             backbone_type = MobileNetV3
     else:
-        raise ValueError(
-            f"Unable to determine backbone from dataset_type: {config.dataset_type}"
-        )
+        raise ValueError(f"Unable to determine backbone from dataset_type: {config.dataset_type}")
     return backbone_type, backbone_kwargs
 
 
 def get_model(
     config: TrainingConfig | EvaluationConfig, return_initializer: bool = False
-) -> DiscreteRegressionNN | tuple[DiscreteRegressionNN, type[DiscreteRegressionNN]]:
-    initializer: Type[DiscreteRegressionNN]
+) -> RegressionNN | tuple[RegressionNN, type[RegressionNN]]:
+    initializer: Type[RegressionNN]
 
     if config.head_type == HeadType.GAUSSIAN:
-        if (
-            hasattr(config, "beta_scheduler_type")
-            and config.beta_scheduler_type is not None
-        ):
+        if hasattr(config, "beta_scheduler_type") and config.beta_scheduler_type is not None:
             initializer = partialclass(
                 GaussianNN,
                 beta_scheduler_type=config.beta_scheduler_type,


### PR DESCRIPTION
1. I got rid of `AverageNLL` in the place of `GaussianNLL` in the `GaussianNN` class, as we have no need for the other hacky metric (with the continuity correction) when we have the pure gaussian NLL values.
2. I found a few places in the repo where the Gaussian was rounding its predicted mean to the nearest integer when asked for a point prediction. This is a legacy carryover from the DDPN project, and shouldn't happen here. So I removed it.
3. I renamed the base class `DiscreteRegressionNN` to `RegressionNN` to more appropriately reflect reality.
4. My linter suggested a bunch of cleanup, which I took care of (mostly unused import statements).